### PR TITLE
Fixing apparent newline bug with `list` type question.

### DIFF
--- a/PyInquirer/prompts/list.py
+++ b/PyInquirer/prompts/list.py
@@ -129,14 +129,11 @@ def question(message, **kwargs):
 
     # assemble layout
     layout = HSplit([
-        Window(content=TokenListControl(get_prompt_tokens, align_center=False)),
+        Window(height=D.exact(1),
+               content=TokenListControl(get_prompt_tokens)
+        ),
         ConditionalContainer(
-            Window(
-                ic,
-                width=D.exact(43),
-                height=D(min=3),
-                scroll_offsets=ScrollOffsets(top=1, bottom=1)
-            ),
+            Window(ic),
             filter=~IsDone()
         )
     ])


### PR DESCRIPTION
Hello,

I was looking for a CLI package for Python and found yours to be suitable for my needs. I installed it but came across an error—whenever I ran your script `examples/list.py`, the prompt ended up printing a bunch of newlines before printing the actual options.

In this pull request, I replaced the `layout` variable from the implementation of the `list` question with the one present in the `rawlist` implementation. This seems to have fixed the issue.

I am not well-versed in this project's implementation, so please test this out on your own computer to confirm the bug and fix are valid.