### PR TITLE
WIP: converted list & confirm to promt toolkit 2

### DIFF
--- a/PyInquirer/__init__.py
+++ b/PyInquirer/__init__.py
@@ -1,29 +1,18 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, print_function
+
 import os
 
-from prompt_toolkit.token import Token
-from prompt_toolkit.styles import style_from_dict
+# noinspection PyUnresolvedReferences
 from prompt_toolkit.validation import Validator, ValidationError
 
-from .utils import print_json, format_json
-
+from PyInquirer.prompt import prompt
+from PyInquirer.separator import Separator
+from PyInquirer.utils import print_json, format_json
 
 __version__ = '1.0.2'
 
 
 def here(p):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), p))
-
-
-class PromptParameterException(ValueError):
-    def __init__(self, message, errors=None):
-
-        # Call the base class constructor with the parameters it needs
-        super(PromptParameterException, self).__init__(
-            'You must provide a `%s` value' % message, errors)
-
-from .prompt import prompt
-from .separator import Separator
-from .prompts.common import default_style

--- a/PyInquirer/constants.py
+++ b/PyInquirer/constants.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -12,6 +14,8 @@ NO = "No"
 YES_OR_NO = "(Y/n)"
 
 NO_OR_YES = "(y/N)"
+
+SELECTED_POINTER = "»"
 
 DEFAULT_STYLE = Style([
     ('qmark', 'fg:#5f819d'),

--- a/PyInquirer/constants.py
+++ b/PyInquirer/constants.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from prompt_toolkit.styles import Style
+
+YES = "Yes"
+
+NO = "No"
+
+YES_OR_NO = "(Y/n)"
+
+NO_OR_YES = "(y/N)"
+
+DEFAULT_STYLE = Style([
+    ('qmark', 'fg:#5f819d'),
+    ('question', 'bold'),
+    ('answer', 'fg:#FF9D00 bold'),
+    ('pointer', ''),
+    ('selected', ''),
+    ('separator', ''),
+])

--- a/PyInquirer/prompts/__init__.py
+++ b/PyInquirer/prompts/__init__.py
@@ -1,0 +1,2 @@
+from PyInquirer.prompts import list
+from PyInquirer.prompts import confirm

--- a/PyInquirer/prompts/common.py
+++ b/PyInquirer/prompts/common.py
@@ -6,25 +6,11 @@ common prompt functionality
 import sys
 
 from prompt_toolkit.validation import Validator, ValidationError
-from prompt_toolkit.styles import style_from_dict
-from prompt_toolkit.token import Token
-from prompt_toolkit.mouse_events import MouseEventTypes
-
 
 PY3 = sys.version_info[0] >= 3
 
 if PY3:
     basestring = str
-
-
-def if_mousedown(handler):
-    def handle_if_mouse_down(cli, mouse_event):
-        if mouse_event.event_type == MouseEventTypes.MOUSE_DOWN:
-            return handler(cli, mouse_event)
-        else:
-            return NotImplemented
-
-    return handle_if_mouse_down
 
 
 # TODO probably better to use base.Condition
@@ -78,15 +64,3 @@ def setup_simple_validator(kwargs):
                 message='invalid input'
                 )
     return _validator
-
-
-# FIXME style defaults on detail level
-default_style = style_from_dict({
-    Token.Separator: '#6C6C6C',
-    Token.QuestionMark: '#5F819D',
-    Token.Selected: '',  # default
-    Token.Pointer: '#FF9D00 bold',  # AWS orange
-    Token.Instruction: '',  # default
-    Token.Answer: '#FF9D00 bold',  # AWS orange
-    Token.Question: 'bold',
-})

--- a/PyInquirer/prompts/confirm.py
+++ b/PyInquirer/prompts/confirm.py
@@ -48,7 +48,7 @@ def question(message,
     @bindings.add(Keys.ControlQ, eager=True)
     @bindings.add(Keys.ControlC, eager=True)
     def _(event):
-        raise KeyboardInterrupt()
+        event.app.exit(exception=KeyboardInterrupt, style='class:aborting')
 
     @bindings.add('n')
     @bindings.add('N')

--- a/PyInquirer/prompts/list.py
+++ b/PyInquirer/prompts/list.py
@@ -151,7 +151,7 @@ def question(message,
     @bindings.add(Keys.ControlQ, eager=True)
     @bindings.add(Keys.ControlC, eager=True)
     def _(event):
-        raise KeyboardInterrupt()
+        event.app.exit(exception=KeyboardInterrupt, style='class:aborting')
 
     @bindings.add(Keys.Down, eager=True)
     def move_cursor_down(event):

--- a/PyInquirer/prompts/list.py
+++ b/PyInquirer/prompts/list.py
@@ -22,7 +22,7 @@ from prompt_toolkit.shortcuts.prompt import (
     PromptSession)
 from prompt_toolkit.styles import merge_styles
 
-from PyInquirer.constants import DEFAULT_STYLE
+from PyInquirer.constants import DEFAULT_STYLE, SELECTED_POINTER
 from PyInquirer.separator import Separator
 
 PY3 = sys.version_info[0] >= 3
@@ -70,13 +70,15 @@ class InquirerControl(FormattedTextControl):
             selected = (index == self.selected_option_index)
 
             if selected:
-                tokens.append(("class:pointer", ' \u276f '))
+                tokens.append(("class:pointer",
+                               ' {} '.format(SELECTED_POINTER)))
                 tokens.append(('[SetCursorPosition]', ''))
             else:
                 tokens.append(("", '   '))
 
             if isinstance(choice[0], Separator):
-                tokens.append(("class:separator", "{}".format(choice[0])))
+                tokens.append(("class:separator",
+                               "{}".format(choice[0])))
             elif choice[2]:  # disabled
                 tokens.append(("class:selected" if selected else "",
                                '- {} ({})'.format(choice[0], choice[2])))

--- a/PyInquirer/utils.py
+++ b/PyInquirer/utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+
+import inspect
 import json
 import sys
 from pprint import pprint
@@ -29,7 +31,46 @@ def colorize_json(data):
 
 
 def print_json(data):
-    #colorful_json = highlight(unicode(format_json(data), 'UTF-8'),
+    # colorful_json = highlight(unicode(format_json(data), 'UTF-8'),
     #                          lexers.JsonLexer(),
     #                          formatters.TerminalFormatter())
     pprint(colorize_json(format_json(data)))
+
+
+def arguments_of(func):
+    """Return the parameters of the function `func`."""
+
+    try:
+        # python 3.x is used
+        return list(inspect.signature(func).defaults)
+    except AttributeError:
+        # python 2.x is used
+        # noinspection PyDeprecation
+        return list(inspect.getargspec(func).defaults)
+
+
+def default_values_of(func):
+    """Return the defaults of the function `func`. """
+
+    try:
+        # python 3.x is used
+        return list(inspect.signature(func).parameters.keys())
+    except AttributeError:
+        # python 2.x is used
+        # noinspection PyDeprecation
+        return list(inspect.getargspec(func).args)
+
+
+def required_arguments(func):
+    """Return all arguments of a function that do not have a default value."""
+    defaults = default_values_of(func)
+    args = arguments_of(func)
+
+    if defaults:
+        args = args[:-len(defaults)]
+    return args   # all args without default values
+
+
+def missing_arguments(func, argdict):
+    """Return all arguments that are missing to call func."""
+    return set(required_arguments(func)) - argdict.keys()

--- a/PyInquirer/utils.py
+++ b/PyInquirer/utils.py
@@ -73,4 +73,4 @@ def required_arguments(func):
 
 def missing_arguments(func, argdict):
     """Return all arguments that are missing to call func."""
-    return set(required_arguments(func)) - argdict.keys()
+    return set(required_arguments(func)) - set(argdict.keys())

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,33 +1,26 @@
-from PyInquirer import style_from_dict, Token
+from prompt_toolkit.styles import Style
 
+custom_style_1 = Style([
+    ('separator', 'fg:#cc5454'),
+    ('qmark', 'fg:#673ab7 bold'),
+    ('question', ''),
+    ('selected', 'fg:#cc5454'),
+    ('pointer', 'fg:#673ab7 bold'),
+    ('answer', 'fg:#f44336 bold'),
+])
 
-custom_style_1 = style_from_dict({
-    Token.Separator: '#cc5454',
-    Token.QuestionMark: '#673ab7 bold',
-    Token.Selected: '#cc5454',  # default
-    Token.Pointer: '#673ab7 bold',
-    Token.Instruction: '',  # default
-    Token.Answer: '#f44336 bold',
-    Token.Question: '',
-})
+custom_style_2 = Style([
+    ('separator', 'fg:#6C6C6C'),
+    ('qmark', 'fg:#FF9D00 bold'),
+    ('question', ''),
+    ('selected', 'fg:#5F819D'),
+    ('pointer', 'fg:#FF9D00 bold'),
+    ('answer', 'fg:#5F819D bold'),
+])
 
-
-custom_style_2 = style_from_dict({
-    Token.Separator: '#6C6C6C',
-    Token.QuestionMark: '#FF9D00 bold',
-    #Token.Selected: '',  # default
-    Token.Selected: '#5F819D',
-    Token.Pointer: '#FF9D00 bold',
-    Token.Instruction: '',  # default
-    Token.Answer: '#5F819D bold',
-    Token.Question: '',
-})
-
-
-custom_style_3 = style_from_dict({
-    Token.QuestionMark: '#E91E63 bold',
-    Token.Selected: '#673AB7 bold',
-    Token.Instruction: '',  # default
-    Token.Answer: '#2196f3 bold',
-    Token.Question: '',
-})
+custom_style_3 = Style([
+    ('qmark', 'fg:#E91E63 bold'),
+    ('question', ''),
+    ('selected', 'fg:#673AB7 bold'),
+    ('answer', 'fg:#2196f3 bold'),
+])

--- a/examples/confirm.py
+++ b/examples/confirm.py
@@ -11,7 +11,6 @@ from PyInquirer import prompt
 
 from examples import custom_style_1
 
-
 questions = [
     {
         'type': 'confirm',
@@ -21,7 +20,10 @@ questions = [
     },
     {
         'type': 'confirm',
-        'message': 'Do you want to exit? Oh, I haven\'t actually experience that. I\'ll look into it. Under your repository name, click Pull requests. Under your repository name, click Pull requests.',
+        'message': "Do you want to exit? Oh, I haven't actually experience "
+                   "that. I'll look into it. Under your repository name, "
+                   "click Pull requests. Under your repository name, "
+                   "click Pull requests.",
         'name': 'exit',
         'default': False,
     },
@@ -29,4 +31,3 @@ questions = [
 
 answers = prompt(questions, style=custom_style_1)
 pprint(answers)
-

--- a/examples/list.py
+++ b/examples/list.py
@@ -6,10 +6,8 @@ from __future__ import print_function, unicode_literals
 
 from pprint import pprint
 
-from PyInquirer import style_from_dict, Token, prompt, Separator
-
+from PyInquirer import prompt, Separator
 from examples import custom_style_2
-
 
 
 def get_delivery_options(answers):


### PR DESCRIPTION
Goal:
Support promt toolkit 2

Description:
- confirm works with promt toolkit 2
- list works with promt toolkit 2

to try it out:
```bash
pip install -U promt_toolkit
python examples/confirm.py
python examples/list.py
```

promt TODO:
- support:
```
patch_stdout=patch_stdout,
return_asyncio_coroutine=return_asyncio_coroutine,
true_color=true_color,
refresh_interval=refresh_interval,
eventloop=eventloop)
```

Related to #14 
Fixes #24 