### PR TITLE
Updated Click Event in list.py

### DIFF
--- a/PyInquirer/prompts/list.py
+++ b/PyInquirer/prompts/list.py
@@ -79,7 +79,7 @@ class InquirerControl(TokenListControl):
                 # bind option with this index to mouse event
                 self.selected_option_index = index
                 self.answered = True
-                cli.set_return_value(None)
+                cli.set_return_value(self.get_selection()[1])
 
             tokens.append((T.Pointer if selected else T, ' \u276f ' if selected
             else '   '))


### PR DESCRIPTION
Previously on mousedown, `None` was returned as the answer regardless what was clicked. This change returns the actual option that was clicked by the mouse, instead of `None`.