### PR TITLE
Improve handling of KeyboardInterrupt in prompt

### DIFF
--- a/PyInquirer/prompt.py
+++ b/PyInquirer/prompt.py
@@ -19,6 +19,7 @@ def prompt(questions, answers=None, **kwargs):
     refresh_interval = kwargs.pop('refresh_interval', 0)
     eventloop = kwargs.pop('eventloop', None)
     kbi_msg = kwargs.pop('keyboard_interrupt_msg', 'Cancelled by user')
+    raise_kbi = kwargs.pop('raise_keyboard_interrupt', False)
 
     for question in questions:
         # import the question
@@ -86,10 +87,13 @@ def prompt(questions, answers=None, **kwargs):
         except AttributeError as e:
             print(e)
             raise ValueError('No question type \'%s\'' % type)
-        except KeyboardInterrupt:
-            print('')
-            print(kbi_msg)
-            print('')
+        except KeyboardInterrupt as exc:
+            if raise_kbi:
+                raise exc from None
+            if kbi_msg:
+                print('')
+                print(kbi_msg)
+                print('')
             return {}
     return answers
 


### PR DESCRIPTION
Hi, I'm proposing two changes in this PR:

1. Do not print the keyboard interrupt message at all if it is empty
2. Add option to re-raise keyboard interrupts (defaults to `False` to keep the current behavior).

2) is motivated by allowing to use PyInquirer in the context of a CLI which already listens to `KeyboardInterrupt` exceptions to cancel execution of the application.