### PR TITLE
editor prompt: only call `issubclass` when the "validate" argument is a class

### DIFF
--- a/PyInquirer/prompts/editor.py
+++ b/PyInquirer/prompts/editor.py
@@ -3,6 +3,7 @@
 `editor` type question
 """
 from __future__ import print_function, unicode_literals
+import inspect
 import os
 import sys
 from prompt_toolkit.token import Token
@@ -136,7 +137,7 @@ def question(message, **kwargs):
     eargs = kwargs.pop('eargs', {})
     validate_prompt = kwargs.pop('validate', None)
     if validate_prompt:
-        if issubclass(validate_prompt, Validator):
+        if inspect.isclass(validate_prompt) and issubclass(validate_prompt, Validator):
             kwargs['validator'] = validate_prompt()
         elif callable(validate_prompt):
             class _InputValidator(Validator):


### PR DESCRIPTION
For some reasons I don't really understand sometimes this causes an exception, sometimes it does not. Anyway, `issubclass` only access class objects as first argument so when the "validate" field is just defined as a function an error is raised. Using `inspect` to check that the passed value is actually a class should fix the issue (this was already employed in `prompts/input.py`).