### PR TITLE
Make the big packages regex and pygments optional

### DIFF
--- a/PyInquirer/utils.py
+++ b/PyInquirer/utils.py
@@ -4,8 +4,6 @@ import json
 import sys
 from pprint import pprint
 
-from pygments import highlight, lexers, formatters
-
 __version__ = '0.1.2'
 
 PY3 = sys.version_info[0] >= 3
@@ -16,16 +14,20 @@ def format_json(data):
 
 
 def colorize_json(data):
-    if PY3:
-        if isinstance(data, bytes):
-            data = data.decode('UTF-8')
-    else:
-        if not isinstance(data, unicode):
-            data = unicode(data, 'UTF-8')
-    colorful_json = highlight(data,
-                              lexers.JsonLexer(),
-                              formatters.TerminalFormatter())
-    return colorful_json
+    try:
+        from pygments import highlight, lexers, formatters
+        if PY3:
+            if isinstance(data, bytes):
+                data = data.decode('UTF-8')
+        else:
+            if not isinstance(data, unicode):
+                data = unicode(data, 'UTF-8')
+        colorful_json = highlight(data,
+                                  lexers.JsonLexer(),
+                                  formatters.TerminalFormatter())
+        return colorful_json
+    except ModuleNotFoundError:
+        return data
 
 
 def print_json(data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 prompt_toolkit>=1.0.16,<1.1
 Pygments>=2.2.0
-regex>=2016.11.21

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ pytest-html>=1.10.1
 pytest-xdist>=1.15.0
 pylint>=1.6.5
 ptyprocess==0.5.1
+regex>=2016.11.21
 
 # build-tools
 pep8>=1.7.0


### PR DESCRIPTION
These big packages slow down and increase the size of my zipapp, so this allows a leaner deployment.
Also see #63 