### PR TITLE
Upgrade code for compatibility with prompt_toolkit 3.0.

### DIFF
--- a/PyInquirer/__init__.py
+++ b/PyInquirer/__init__.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
 import os
-
-# from prompt_toolkit.token import Token
-# from prompt_toolkit.styles import style_from_dict
-# from prompt_toolkit.validation import Validator, ValidationError
 
 from .utils import print_json, format_json
 
@@ -21,9 +16,22 @@ class PromptParameterException(ValueError):
     def __init__(self, message, errors=None):
 
         # Call the base class constructor with the parameters it needs
-        super(PromptParameterException, self).__init__(
-            'You must provide a `%s` value' % message, errors)
+        super().__init__('You must provide a `%s` value' % message, errors)
 
 from .prompt import prompt
 from .separator import Separator
 from .prompts.common import default_style
+
+
+# The code below here is here because of backwards-compatibility. Before,
+# people were using style_from_dict and importing it from here. It's better to
+# use Style.from_dict, as recommended by prompt_toolkit now.
+from prompt_toolkit.styles import Style
+def style_from_dict(style_dict):
+    # Deprecated function. Users should use Style.from_dict instead.
+    # Keep this here for backwards-compatibility.
+    return Style.from_dict({
+        '.'.join(key).lower(): value for key, value in style_dict.items()
+    })
+from pygments.token import Token
+from prompt_toolkit.validation import Validator, ValidationError

--- a/PyInquirer/color_print.py
+++ b/PyInquirer/color_print.py
@@ -2,21 +2,17 @@
 """
 provide colorized output
 """
-from __future__ import print_function, unicode_literals
 import sys
-from prompt_toolkit.shortcuts import print_tokens, style_from_dict, Token
+from prompt_toolkit.shortcuts import print_tokens
 
 
 def _print_token_factory(col):
     """Internal helper to provide color names."""
     def _helper(msg):
-        style = style_from_dict({
-            Token.Color: col,
-        })
         tokens = [
-            (Token.Color, msg)
+            ('fg:' + col, msg)
         ]
-        print_tokens(tokens, style=style)
+        print_tokens(tokens)
 
     def _helper_no_terminal(msg):
         # workaround if we have no terminal

--- a/PyInquirer/prompts/checkbox.py
+++ b/PyInquirer/prompts/checkbox.py
@@ -2,27 +2,24 @@
 """
 `checkbox` type question
 """
-from __future__ import print_function, unicode_literals
 from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.keys import Keys
-from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.filters import IsDone
-from prompt_toolkit.layout.controls import TokenListControl
+from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.containers import ConditionalContainer, \
-    ScrollOffsets, HSplit
+    ScrollOffsets, HSplit, Window, WindowAlign
 from prompt_toolkit.layout.dimension import LayoutDimension as D
-from prompt_toolkit.token import Token
+from prompt_toolkit.layout import Layout
 
 from .. import PromptParameterException
 from ..separator import Separator
 from .common import setup_simple_validator, default_style, if_mousedown
 
 
-# custom control based on TokenListControl
+# custom control based on FormattedTextControl
 
 
-class InquirerControl(TokenListControl):
+class InquirerControl(FormattedTextControl):
     def __init__(self, choices, pointer_index, **kwargs):
         self.pointer_index = pointer_index
         self.pointer_sign = kwargs.pop("pointer_sign", "\u276f")
@@ -31,8 +28,7 @@ class InquirerControl(TokenListControl):
         self.selected_options = []  # list of names
         self.answered = False
         self._init_choices(choices)
-        super(InquirerControl, self).__init__(self._get_choice_tokens,
-                                              **kwargs)
+        super().__init__(self._get_choice_tokens, **kwargs)
 
     def _init_choices(self, choices):
         # helper to convert from question format to internal format
@@ -57,13 +53,12 @@ class InquirerControl(TokenListControl):
     def choice_count(self):
         return len(self.choices)
 
-    def _get_choice_tokens(self, cli):
+    def _get_choice_tokens(self):
         tokens = []
-        T = Token
 
         def append(index, line):
             if isinstance(line, Separator):
-                tokens.append((T.Separator, '  %s\n' % line))
+                tokens.append(('class:Separator', '  %s\n' % line))
             else:
                 line_name = line[0]
                 line_value = line[1]
@@ -71,7 +66,7 @@ class InquirerControl(TokenListControl):
                 pointed_at = (index == self.pointer_index)
 
                 @if_mousedown
-                def select_item(cli, mouse_event):
+                def select_item(mouse_event):
                     # bind option with this index to mouse event
                     if line_value in self.selected_options:
                         self.selected_options.remove(line_value)
@@ -79,26 +74,26 @@ class InquirerControl(TokenListControl):
                         self.selected_options.append(line_value)
 
                 if pointed_at:
-                    tokens.append((T.Pointer, ' {}'.format(self.pointer_sign), select_item))  # ' >'
+                    tokens.append(('class:pointer', ' {}'.format(self.pointer_sign), select_item))  # ' >'
                 else:
-                    tokens.append((T, '  ', select_item))
+                    tokens.append(('', '  ', select_item))
                 # 'o ' - FISHEYE
                 if choice[2]:  # disabled
-                    tokens.append((T, '- %s (%s)' % (choice[0], choice[2])))
+                    tokens.append(('', '- %s (%s)' % (choice[0], choice[2])))
                 else:
                     if selected:
-                        tokens.append((T.Selected, '{} '.format(self.selected_sign), select_item))
+                        tokens.append(('class:selected', '{} '.format(self.selected_sign), select_item))
                     else:
-                        tokens.append((T, '{} '.format(self.unselected_sign), select_item))
+                        tokens.append(('', '{} '.format(self.unselected_sign), select_item))
 
                     if pointed_at:
-                        tokens.append((Token.SetCursorPosition, ''))
+                        tokens.append(('[SetCursorPosition]', ''))
 
                     if choice[3]:  # description
-                        tokens.append((T, "%s - %s" % (line_name, choice[3])))
+                        tokens.append(('', "%s - %s" % (line_name, choice[3])))
                     else:
-                        tokens.append((T, line_name, select_item))
-                tokens.append((T, '\n'))
+                        tokens.append(('', line_name, select_item))
+                tokens.append(('', '\n'))
 
         # prepare the select choices
         for i, choice in enumerate(self.choices):
@@ -142,22 +137,22 @@ def question(message, **kwargs):
     ic = InquirerControl(choices, pointer_index, **additional_parameters)
     qmark = kwargs.pop('qmark', '?')
 
-    def get_prompt_tokens(cli):
+    def get_prompt_tokens():
         tokens = []
 
-        tokens.append((Token.QuestionMark, qmark))
-        tokens.append((Token.Question, ' %s ' % message))
+        tokens.append(('class:questionmark', qmark))
+        tokens.append(('class:question', ' %s ' % message))
         if ic.answered:
             nbr_selected = len(ic.selected_options)
             if nbr_selected == 0:
-                tokens.append((Token.Answer, ' done'))
+                tokens.append(('class:answer', ' done'))
             elif nbr_selected == 1:
-                tokens.append((Token.Answer, ' [%s]' % ic.selected_options[0]))
+                tokens.append(('class:Answer', ' [%s]' % ic.selected_options[0]))
             else:
-                tokens.append((Token.Answer,
+                tokens.append(('class:answer',
                                ' done (%d selections)' % nbr_selected))
         else:
-            tokens.append((Token.Instruction,
+            tokens.append(('class:instruction',
                            ' (<up>, <down> to move, <space> to select, <a> '
                            'to toggle, <i> to invert)'))
         return tokens
@@ -165,7 +160,8 @@ def question(message, **kwargs):
     # assemble layout
     layout = HSplit([
         Window(height=D.exact(1),
-               content=TokenListControl(get_prompt_tokens, align_center=False)
+               content=FormattedTextControl(get_prompt_tokens),
+               align=WindowAlign.CENTER,
         ),
         ConditionalContainer(
             Window(
@@ -179,15 +175,15 @@ def question(message, **kwargs):
     ])
 
     # key bindings
-    manager = KeyBindingManager.for_prompt()
+    kb = KeyBindings()
 
-    @manager.registry.add_binding(Keys.ControlQ, eager=True)
-    @manager.registry.add_binding(Keys.ControlC, eager=True)
+    @kb.add('c-q', eager=True)
+    @kb.add('c-c', eager=True)
     def _(event):
         raise KeyboardInterrupt()
-        # event.cli.set_return_value(None)
+        # event.app.exit(result=None)
 
-    @manager.registry.add_binding(' ', eager=True)
+    @kb.add(' ', eager=True)
     def toggle(event):
         pointed_choice = ic.choices[ic.pointer_index][1]  # value
         if pointed_choice in ic.selected_options:
@@ -195,7 +191,7 @@ def question(message, **kwargs):
         else:
             ic.selected_options.append(pointed_choice)
 
-    @manager.registry.add_binding('i', eager=True)
+    @kb.add('i', eager=True)
     def invert(event):
         inverted_selection = [c[1] for c in ic.choices if
                               not isinstance(c, Separator) and
@@ -203,7 +199,7 @@ def question(message, **kwargs):
                               not c[2]]
         ic.selected_options = inverted_selection
 
-    @manager.registry.add_binding('a', eager=True)
+    @kb.add('a', eager=True)
     def all(event):
         all_selected = True  # all choices have been selected
         for c in ic.choices:
@@ -214,7 +210,7 @@ def question(message, **kwargs):
         if all_selected:
             ic.selected_options = []
 
-    @manager.registry.add_binding(Keys.Down, eager=True)
+    @kb.add('down', eager=True)
     def move_cursor_down(event):
         def _next():
             ic.pointer_index = ((ic.pointer_index + 1) % ic.line_count)
@@ -223,7 +219,7 @@ def question(message, **kwargs):
                 ic.choices[ic.pointer_index][2]:
             _next()
 
-    @manager.registry.add_binding(Keys.Up, eager=True)
+    @kb.add('up', eager=True)
     def move_cursor_up(event):
         def _prev():
             ic.pointer_index = ((ic.pointer_index - 1) % ic.line_count)
@@ -232,15 +228,15 @@ def question(message, **kwargs):
                 ic.choices[ic.pointer_index][2]:
             _prev()
 
-    @manager.registry.add_binding(Keys.Enter, eager=True)
+    @kb.add('enter', eager=True)
     def set_answer(event):
         ic.answered = True
         # TODO use validator
-        event.cli.set_return_value(ic.get_selected_values())
+        event.app.exit(result=ic.get_selected_values())
 
     return Application(
-        layout=layout,
-        key_bindings_registry=manager.registry,
+        layout=Layout(layout),
+        key_bindings=kb,
         mouse_support=True,
         style=style
     )

--- a/PyInquirer/prompts/common.py
+++ b/PyInquirer/prompts/common.py
@@ -2,25 +2,15 @@
 """
 common prompt functionality
 """
-
-import sys
-
 from prompt_toolkit.validation import Validator, ValidationError
-from prompt_toolkit.styles import style_from_dict
-from prompt_toolkit.token import Token
-from prompt_toolkit.mouse_events import MouseEventTypes
-
-
-PY3 = sys.version_info[0] >= 3
-
-if PY3:
-    basestring = str
+from prompt_toolkit.styles import Style
+from prompt_toolkit.mouse_events import MouseEventType
 
 
 def if_mousedown(handler):
-    def handle_if_mouse_down(cli, mouse_event):
-        if mouse_event.event_type == MouseEventTypes.MOUSE_DOWN:
-            return handler(cli, mouse_event)
+    def handle_if_mouse_down(mouse_event):
+        if mouse_event.event_type == MouseEventType.MOUSE_DOWN:
+            return handler(mouse_event)
         else:
             return NotImplemented
 
@@ -40,7 +30,7 @@ def setup_validator(kwargs):
                 def validate(self, document):
                     #print('validation!!')
                     verdict = validate_prompt(document.text)
-                    if isinstance(verdict, basestring):
+                    if isinstance(verdict, str):
                         raise ValidationError(
                             message=verdict,
                             cursor_position=len(document.text))
@@ -69,7 +59,7 @@ def setup_simple_validator(kwargs):
 
     def _validator(answer):
         verdict = validate(answer)
-        if isinstance(verdict, basestring):
+        if isinstance(verdict, str):
             raise ValidationError(
                 message=verdict
                 )
@@ -81,12 +71,12 @@ def setup_simple_validator(kwargs):
 
 
 # FIXME style defaults on detail level
-default_style = style_from_dict({
-    Token.Separator: '#6C6C6C',
-    Token.QuestionMark: '#5F819D',
-    Token.Selected: '',  # default
-    Token.Pointer: '#FF9D00 bold',  # AWS orange
-    Token.Instruction: '',  # default
-    Token.Answer: '#FF9D00 bold',  # AWS orange
-    Token.Question: 'bold',
+default_style = Style.from_dict({
+    'separator': '#6C6C6C',
+    'questionmark': '#5F819D',
+    'selected': '',  # default
+    'pointer': '#FF9D00 bold',  # AWS orange
+    'instruction': '',  # default
+    'answer': '#FF9D00 bold',  # AWS orange
+    'question': 'bold',
 })

--- a/PyInquirer/prompts/confirm.py
+++ b/PyInquirer/prompts/confirm.py
@@ -2,19 +2,9 @@
 """
 confirm type question
 """
-from __future__ import print_function, unicode_literals
-from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.keys import Keys
-from prompt_toolkit.layout.containers import Window, HSplit
-from prompt_toolkit.layout.controls import TokenListControl
-from prompt_toolkit.layout.dimension import LayoutDimension as D
-from prompt_toolkit.token import Token
-from prompt_toolkit.shortcuts import create_prompt_application
-from prompt_toolkit.styles import style_from_dict
-
-
-# custom control based on TokenListControl
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.shortcuts import PromptSession
+from prompt_toolkit.styles import Style
 
 
 def question(message, **kwargs):
@@ -22,60 +12,60 @@ def question(message, **kwargs):
     default = kwargs.pop('default', True)
 
     # TODO style defaults on detail level
-    style = kwargs.pop('style', style_from_dict({
-        Token.QuestionMark: '#5F819D',
-        #Token.Selected: '#FF9D00',  # AWS orange
-        Token.Instruction: '',  # default
-        Token.Answer: '#FF9D00 bold',  # AWS orange
-        Token.Question: 'bold',
+    style = kwargs.pop('style', Style.from_dict({
+        'questionmark': '#5F819D',
+        #'selected': '#FF9D00',  # AWS orange
+        'instruction': '',  # default
+        'answer': '#FF9D00 bold',  # AWS orange
+        'question': 'bold',
     }))
     status = {'answer': None}
 
     qmark = kwargs.pop('qmark', '?')
 
-    def get_prompt_tokens(cli):
+    def get_prompt_tokens():
         tokens = []
 
-        tokens.append((Token.QuestionMark, qmark))
-        tokens.append((Token.Question, ' %s ' % message))
+        tokens.append(('class:questionmark', qmark))
+        tokens.append(('class:question', ' %s ' % message))
         if isinstance(status['answer'], bool):
-            tokens.append((Token.Answer, ' Yes' if status['answer'] else ' No'))
+            tokens.append(('class:answer', ' Yes' if status['answer'] else ' No'))
         else:
             if default:
                 instruction = ' (Y/n)'
             else:
                 instruction = ' (y/N)'
-            tokens.append((Token.Instruction, instruction))
+            tokens.append(('class:instruction', instruction))
         return tokens
 
     # key bindings
-    manager = KeyBindingManager.for_prompt()
+    kb = KeyBindings()
 
-    @manager.registry.add_binding(Keys.ControlQ, eager=True)
-    @manager.registry.add_binding(Keys.ControlC, eager=True)
+    @kb.add('c-q', eager=True)
+    @kb.add('c-c', eager=True)
     def _(event):
         raise KeyboardInterrupt()
 
-    @manager.registry.add_binding('n')
-    @manager.registry.add_binding('N')
+    @kb.add('n')
+    @kb.add('N')
     def key_n(event):
         status['answer'] = False
-        event.cli.set_return_value(False)
+        event.app.exit(result=False)
 
-    @manager.registry.add_binding('y')
-    @manager.registry.add_binding('Y')
+    @kb.add('y')
+    @kb.add('Y')
     def key_y(event):
         status['answer'] = True
-        event.cli.set_return_value(True)
+        event.app.exit(result=True)
 
-    @manager.registry.add_binding(Keys.Enter, eager=True)
+    @kb.add('enter', eager=True)
     def set_answer(event):
         status['answer'] = default
-        event.cli.set_return_value(default)
+        event.app.exit(result=default)
 
-    return create_prompt_application(
-        get_prompt_tokens=get_prompt_tokens,
-        key_bindings_registry=manager.registry,
+    return PromptSession(
+        message=get_prompt_tokens,
+        key_bindings=kb,
         mouse_support=False,
         style=style,
         erase_when_done=False,

--- a/PyInquirer/prompts/editor.py
+++ b/PyInquirer/prompts/editor.py
@@ -2,14 +2,12 @@
 """
 `editor` type question
 """
-from __future__ import print_function, unicode_literals
 import inspect
 import os
 import sys
-from prompt_toolkit.token import Token
-from prompt_toolkit.shortcuts import create_prompt_application
+from prompt_toolkit.shortcuts import PromptSession
 from prompt_toolkit.validation import Validator, ValidationError
-from prompt_toolkit.layout.lexers import SimpleLexer
+from prompt_toolkit.lexers import SimpleLexer
 
 from .common import default_style
 
@@ -21,7 +19,7 @@ WIN = sys.platform.startswith('win')
 class EditorArgumentsError(Exception):
     pass
 
-class Editor(object):
+class Editor:
 
     def __init__(self, editor=None, env=None, require_save=True, extension='.txt'):
         self.editor = editor
@@ -183,15 +181,15 @@ def question(message, **kwargs):
     kwargs['style'] = kwargs.pop('style', default_style)
     qmark = kwargs.pop('qmark', '?')
     
-    def _get_prompt_tokens(cli):
+    def _get_prompt_tokens():
         return [
-            (Token.QuestionMark, qmark),
-            (Token.Question, ' %s  ' % message)
+            ('class:questionmark', qmark),
+            ('class:question', ' %s  ' % message)
         ]
 
-    return create_prompt_application(
-        get_prompt_tokens=_get_prompt_tokens,
-        lexer=SimpleLexer(Token.Answer),
+    return PromptSession(
+        message=_get_prompt_tokens,
+        lexer=SimpleLexer('class:answer'),
         default=default,
         multiline=multiline,
         **kwargs

--- a/PyInquirer/prompts/input.py
+++ b/PyInquirer/prompts/input.py
@@ -2,12 +2,10 @@
 """
 `input` type question
 """
-from __future__ import print_function, unicode_literals
 import inspect
-from prompt_toolkit.token import Token
-from prompt_toolkit.shortcuts import create_prompt_application
+from prompt_toolkit.shortcuts import prompt
 from prompt_toolkit.validation import Validator, ValidationError
-from prompt_toolkit.layout.lexers import SimpleLexer
+from prompt_toolkit.lexers import SimpleLexer
 
 from .common import default_style
 
@@ -37,15 +35,15 @@ def question(message, **kwargs):
     qmark = kwargs.pop('qmark', '?')
 
 
-    def _get_prompt_tokens(cli):
+    def _get_prompt_tokens():
         return [
-            (Token.QuestionMark, qmark),
-            (Token.Question, ' %s  ' % message)
+            ('class:questionmark', qmark),
+            ('class:question', ' %s  ' % message)
         ]
 
-    return create_prompt_application(
-        get_prompt_tokens=_get_prompt_tokens,
-        lexer=SimpleLexer(Token.Answer),
+    return prompt(
+        message=_get_prompt_tokens,
+        lexer=SimpleLexer('class:answer'),
         default=default,
         **kwargs
     )

--- a/PyInquirer/prompts/list.py
+++ b/PyInquirer/prompts/list.py
@@ -2,47 +2,33 @@
 """
 `list` type question
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import sys
-
-from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.keys import Keys
+from prompt_toolkit.application import Application, get_app
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.filters import IsDone
-from prompt_toolkit.layout.controls import TokenListControl
-from prompt_toolkit.layout.containers import ConditionalContainer, \
-    ScrollOffsets, HSplit
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.containers import ConditionalContainer, HSplit
 from prompt_toolkit.layout.dimension import LayoutDimension as D
-from prompt_toolkit.token import Token
+from prompt_toolkit.layout import Layout
 
 from .. import PromptParameterException
 from ..separator import Separator
 from .common import if_mousedown, default_style
 
-# custom control based on TokenListControl
+# custom control based on FormattedTextControl
 # docu here:
 # https://github.com/jonathanslenders/python-prompt-toolkit/issues/281
 # https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/examples/full-screen-layout.py
 # https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/docs/pages/full_screen_apps.rst
 
 
-PY3 = sys.version_info[0] >= 3
-
-if PY3:
-    basestring = str
-
-
-class InquirerControl(TokenListControl):
+class InquirerControl(FormattedTextControl):
     def __init__(self, choices, default, **kwargs):
         self.selected_option_index = 0
         self.answered = False
         self.choices = choices
         self._init_choices(choices, default)
-        super(InquirerControl, self).__init__(self._get_choice_tokens,
-                                              **kwargs)
+        super().__init__(self._get_choice_tokens, **kwargs)
 
     def _init_choices(self, choices, default):
         # helper to convert from question format to internal format
@@ -52,7 +38,7 @@ class InquirerControl(TokenListControl):
             if isinstance(c, Separator):
                 self.choices.append((c, None, None))
             else:
-                if isinstance(c, basestring):
+                if isinstance(c, str):
                     self.choices.append((c, c, None))
                 else:
                     name = c.get('name')
@@ -73,38 +59,37 @@ class InquirerControl(TokenListControl):
     def choice_count(self):
         return len(self.choices)
 
-    def _get_choice_tokens(self, cli):
+    def _get_choice_tokens(self):
         tokens = []
-        T = Token
 
         def append(index, choice):
             selected = (index == self.selected_option_index)
 
             @if_mousedown
-            def select_item(cli, mouse_event):
+            def select_item(mouse_event):
                 # bind option with this index to mouse event
                 self.selected_option_index = index
                 self.answered = True
-                cli.set_return_value(self.get_selection()[0])
+                get_app().exit(result=self.get_selection()[0])
 
             if isinstance(choice[0], Separator):
-                tokens.append((T.Separator, '  %s\n' % choice[0]))
+                tokens.append(('class:separator', '  %s\n' % choice[0]))
             else:
-                tokens.append((T.Pointer if selected else T, ' \u276f ' if selected
+                tokens.append(('class:pointer' if selected else '', ' \u276f ' if selected
                 else '   '))
                 if selected:
-                    tokens.append((Token.SetCursorPosition, ''))
+                    tokens.append(('[SetCursorPosition]', ''))
                 if choice[2]:  # disabled
-                    tokens.append((T.Selected if selected else T,
+                    tokens.append(('class:Selected' if selected else '',
                                    '- %s (%s)' % (choice[0], choice[2])))
                 else:
                     try:
-                        tokens.append((T.Selected if selected else T, str(choice[0]),
+                        tokens.append(('class:Selected' if selected else '', str(choice[0]),
                                     select_item))
                     except:
-                        tokens.append((T.Selected if selected else T, choice[0],
+                        tokens.append(('class:Selected' if selected else '', choice[0],
                                     select_item))
-                tokens.append((T, '\n'))
+                tokens.append(('', '\n'))
 
         # prepare the select choices
         for i, choice in enumerate(self.choices):
@@ -129,21 +114,21 @@ def question(message, **kwargs):
 
     ic = InquirerControl(choices, default=default)
 
-    def get_prompt_tokens(cli):
+    def get_prompt_tokens():
         tokens = []
 
-        tokens.append((Token.QuestionMark, qmark))
-        tokens.append((Token.Question, ' %s ' % message))
+        tokens.append(('class:questionmark', qmark))
+        tokens.append(('class:question', ' %s ' % message))
         if ic.answered:
-            tokens.append((Token.Answer, ' ' + ic.get_selection()[0]))
+            tokens.append(('class:answer', ' ' + ic.get_selection()[0]))
         else:
-            tokens.append((Token.Instruction, ' (Use arrow keys)'))
+            tokens.append(('class:instruction', ' (Use arrow keys)'))
         return tokens
 
     # assemble layout
     layout = HSplit([
         Window(height=D.exact(1),
-               content=TokenListControl(get_prompt_tokens)
+               content=FormattedTextControl(get_prompt_tokens)
         ),
         ConditionalContainer(
             Window(ic),
@@ -152,15 +137,15 @@ def question(message, **kwargs):
     ])
 
     # key bindings
-    manager = KeyBindingManager.for_prompt()
+    kb = KeyBindings()
 
-    @manager.registry.add_binding(Keys.ControlQ, eager=True)
-    @manager.registry.add_binding(Keys.ControlC, eager=True)
+    @kb.add('c-q', eager=True)
+    @kb.add('c-c', eager=True)
     def _(event):
         raise KeyboardInterrupt()
-        # event.cli.set_return_value(None)
+        # event.app.exit(result=None)
 
-    @manager.registry.add_binding(Keys.Down, eager=True)
+    @kb.add('down', eager=True)
     def move_cursor_down(event):
         def _next():
             ic.selected_option_index = (
@@ -170,7 +155,7 @@ def question(message, **kwargs):
                 ic.choices[ic.selected_option_index][2]:
             _next()
 
-    @manager.registry.add_binding(Keys.Up, eager=True)
+    @kb.add('up', eager=True)
     def move_cursor_up(event):
         def _prev():
             ic.selected_option_index = (
@@ -180,14 +165,14 @@ def question(message, **kwargs):
                 ic.choices[ic.selected_option_index][2]:
             _prev()
 
-    @manager.registry.add_binding(Keys.Enter, eager=True)
+    @kb.add('enter', eager=True)
     def set_answer(event):
         ic.answered = True
-        event.cli.set_return_value(ic.get_selection()[1])
+        event.app.exit(result=ic.get_selection()[1])
 
     return Application(
-        layout=layout,
-        key_bindings_registry=manager.registry,
+        layout=Layout(layout),
+        key_bindings=kb,
         mouse_support=True,
         style=style
     )

--- a/PyInquirer/prompts/password.py
+++ b/PyInquirer/prompts/password.py
@@ -2,8 +2,6 @@
 """
 `password` type question
 """
-from __future__ import print_function, unicode_literals
-
 from . import input 
 
 # use std prompt-toolkit control

--- a/PyInquirer/prompts/rawlist.py
+++ b/PyInquirer/prompts/rawlist.py
@@ -2,18 +2,13 @@
 """
 `rawlist` type question
 """
-from __future__ import print_function, unicode_literals
-import sys
-
 from prompt_toolkit.application import Application
-from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.keys import Keys
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.filters import IsDone
-from prompt_toolkit.layout.controls import TokenListControl
+from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.containers import ConditionalContainer, HSplit
 from prompt_toolkit.layout.dimension import LayoutDimension as D
-from prompt_toolkit.token import Token
 
 from .. import PromptParameterException
 from ..separator import Separator
@@ -21,21 +16,14 @@ from .common import default_style
 from .common import if_mousedown
 
 
-PY3 = sys.version_info[0] >= 3
+# custom control based on FormattedTextControl
 
-if PY3:
-    basestring = str
-
-
-# custom control based on TokenListControl
-
-class InquirerControl(TokenListControl):
+class InquirerControl(FormattedTextControl):
     def __init__(self, choices, **kwargs):
         self.pointer_index = 0
         self.answered = False
         self._init_choices(choices)
-        super(InquirerControl, self).__init__(self._get_choice_tokens,
-                                              **kwargs)
+        super().__init__(self._get_choice_tokens, **kwargs)
 
     def _init_choices(self, choices):
         # helper to convert from question format to internal format
@@ -46,7 +34,7 @@ class InquirerControl(TokenListControl):
             if isinstance(c, Separator):
                 self.choices.append(c)
             else:
-                if isinstance(c, basestring):
+                if isinstance(c, str):
                     self.choices.append((key, c, c))
                     key += 1
                 if searching_first_choice:
@@ -57,36 +45,35 @@ class InquirerControl(TokenListControl):
     def choice_count(self):
         return len(self.choices)
 
-    def _get_choice_tokens(self, cli):
+    def _get_choice_tokens(self):
         tokens = []
-        T = Token
 
         def _append(index, line):
             if isinstance(line, Separator):
-                tokens.append((T.Separator, '   %s\n' % line))
+                tokens.append(('class:separator', '   %s\n' % line))
             else:
                 key = line[0]
                 line = line[1]
                 pointed_at = (index == self.pointer_index)
 
                 @if_mousedown
-                def select_item(cli, mouse_event):
+                def select_item(mouse_event):
                     # bind option with this index to mouse event
                     self.pointer_index = index
 
                 if pointed_at:
-                    tokens.append((T.Selected, '  %d) %s' % (key, line),
+                    tokens.append(('class:selected', '  %d) %s' % (key, line),
                                    select_item))
                 else:
-                    tokens.append((T, '  %d) %s' % (key, line),
+                    tokens.append(('', '  %d) %s' % (key, line),
                                    select_item))
 
-                tokens.append((T, '\n'))
+                tokens.append(('', '\n'))
 
         # prepare the select choices
         for i, choice in enumerate(self.choices):
             _append(i, choice)
-        tokens.append((T, '  Answer: %d' % self.choices[self.pointer_index][0]))
+        tokens.append(('', '  Answer: %d' % self.choices[self.pointer_index][0]))
         return tokens
 
     def get_selected_value(self):
@@ -113,20 +100,19 @@ def question(message, **kwargs):
 
     ic = InquirerControl(choices)
 
-    def get_prompt_tokens(cli):
+    def get_prompt_tokens():
         tokens = []
-        T = Token
 
-        tokens.append((T.QuestionMark, qmark))
-        tokens.append((T.Question, ' %s ' % message))
+        tokens.append(('class:questionmark', qmark))
+        tokens.append(('class:question', ' %s ' % message))
         if ic.answered:
-            tokens.append((T.Answer, ' %s' % ic.get_selected_value()))
+            tokens.append(('class:answer', ' %s' % ic.get_selected_value()))
         return tokens
 
     # assemble layout
     layout = HSplit([
         Window(height=D.exact(1),
-               content=TokenListControl(get_prompt_tokens)
+               content=FormattedTextControl(get_prompt_tokens)
         ),
         ConditionalContainer(
             Window(ic),
@@ -135,10 +121,10 @@ def question(message, **kwargs):
     ])
 
     # key bindings
-    manager = KeyBindingManager.for_prompt()
+    kb = KeyBindings()
 
-    @manager.registry.add_binding(Keys.ControlQ, eager=True)
-    @manager.registry.add_binding(Keys.ControlC, eager=True)
+    @kb.add('c-q', eager=True)
+    @kb.add('c-c', eager=True)
     def _(event):
         raise KeyboardInterrupt()
 
@@ -148,19 +134,19 @@ def question(message, **kwargs):
             def _reg_binding(i, keys):
                 # trick out late evaluation with a "function factory":
                 # http://stackoverflow.com/questions/3431676/creating-functions-in-a-loop
-                @manager.registry.add_binding(keys, eager=True)
+                @kb.add(keys, eager=True)
                 def select_choice(event):
                     ic.pointer_index = i
             _reg_binding(i, '%d' % c[0])
 
-    @manager.registry.add_binding(Keys.Enter, eager=True)
+    @kb.add('enter', eager=True)
     def set_answer(event):
         ic.answered = True
-        event.cli.set_return_value(ic.get_selected_value())
+        event.app.exit(result=ic.get_selected_value())
 
     return Application(
         layout=layout,
-        key_bindings_registry=manager.registry,
+        key_bindings=kb,
         mouse_support=True,
         style=style
     )

--- a/PyInquirer/separator.py
+++ b/PyInquirer/separator.py
@@ -4,7 +4,7 @@ Used to space/separate choices group
 """
 
 
-class Separator(object):
+class Separator:
     line = '-' * 15
 
     def __init__(self, line=None):

--- a/PyInquirer/utils.py
+++ b/PyInquirer/utils.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import json
-import sys
-from pprint import pprint
 
 __version__ = '0.1.2'
-
-PY3 = sys.version_info[0] >= 3
 
 
 def format_json(data):
@@ -16,12 +11,8 @@ def format_json(data):
 def colorize_json(data):
     try:
         from pygments import highlight, lexers, formatters
-        if PY3:
-            if isinstance(data, bytes):
-                data = data.decode('UTF-8')
-        else:
-            if not isinstance(data, unicode):
-                data = unicode(data, 'UTF-8')
+        if isinstance(data, bytes):
+            data = data.decode('UTF-8')
         colorful_json = highlight(data,
                                   lexers.JsonLexer(),
                                   formatters.TerminalFormatter())
@@ -34,4 +25,4 @@ def print_json(data):
     #colorful_json = highlight(unicode(format_json(data), 'UTF-8'),
     #                          lexers.JsonLexer(),
     #                          formatters.TerminalFormatter())
-    pprint(colorize_json(format_json(data)))
+    print(colorize_json(format_json(data)))

--- a/examples/checkbox.py
+++ b/examples/checkbox.py
@@ -3,11 +3,9 @@
 * Checkbox question example
 * run example by typing `python example/checkbox.py` in your console
 """
-from __future__ import print_function, unicode_literals
-
 from pprint import pprint
 
-from PyInquirer import style_from_dict, Token, prompt, Separator
+from PyInquirer import prompt, Separator
 
 from examples import custom_style_2
 

--- a/examples/confirm.py
+++ b/examples/confirm.py
@@ -3,8 +3,6 @@
 * Confirm question example
 * run example by typing `python example/confirm.py` in your console
 """
-from __future__ import print_function
-
 from pprint import pprint
 
 from PyInquirer import prompt

--- a/examples/editor.py
+++ b/examples/editor.py
@@ -2,8 +2,6 @@
 """
 * Editor prompt example
 """
-from __future__ import print_function, unicode_literals
-
 from PyInquirer import style_from_dict, Token, prompt, print_json
 from PyInquirer import Validator, ValidationError
 from examples import custom_style_2

--- a/examples/expand.py
+++ b/examples/expand.py
@@ -3,8 +3,6 @@
 * example for expand question type
 * run example by typing `python example/checkbox.py` in your console
 """
-from __future__ import print_function, unicode_literals
-
 from PyInquirer import style_from_dict, Token, prompt, print_json, Separator
 
 from examples import custom_style_2

--- a/examples/hierarchical.py
+++ b/examples/hierarchical.py
@@ -2,8 +2,6 @@
 """
 hierarchical prompt usage example
 """
-from __future__ import print_function, unicode_literals
-
 from PyInquirer import style_from_dict, Token, prompt
 
 from examples import custom_style_2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prompt_toolkit>=1.0.16,<1.1
+prompt_toolkit>=3.0.0,<3.1.0
 Pygments>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     long_description=long_description,
     license='MIT',
     url='https://github.com/CITGuru/PyInquirer/',
+    python_requires=">=3.6.1",
     classifiers=[
         'Development Status :: 1 - Planning',
         'Natural Language :: English',

--- a/tests/example_app.py
+++ b/tests/example_app.py
@@ -2,7 +2,6 @@
 """
 example app to test running an app as subprocess within pty
 """
-from __future__ import print_function, unicode_literals
 import sys, time
 
 

--- a/tests/test_example_checkbox.py
+++ b/tests/test_example_checkbox.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import create_example_fixture, keys

--- a/tests/test_example_expand.py
+++ b/tests/test_example_expand.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys

--- a/tests/test_example_hierachical.py
+++ b/tests/test_example_hierachical.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys, create_example_fixture

--- a/tests/test_example_input.py
+++ b/tests/test_example_input.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys

--- a/tests/test_example_list.py
+++ b/tests/test_example_list.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys

--- a/tests/test_example_password.py
+++ b/tests/test_example_password.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import create_example_fixture
@@ -10,7 +9,7 @@ example_app = create_example_fixture('examples/password.py')
 
 def test_password(example_app):
     example_app.expect(textwrap.dedent("""\
-        ? Enter your git password  """))
+        ? Enter your git password"""))
     example_app.writeline('asdf')
     example_app.expect(textwrap.dedent("""\
         ? Enter your git password  ****

--- a/tests/test_example_pizza.py
+++ b/tests/test_example_pizza.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import create_example_fixture, keys

--- a/tests/test_example_rawlist.py
+++ b/tests/test_example_rawlist.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys

--- a/tests/test_example_when.py
+++ b/tests/test_example_when.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 import textwrap
 
 from .helpers import keys

--- a/tests/test_prompts_list.py
+++ b/tests/test_prompts_list.py
@@ -11,7 +11,7 @@ def test_select_first_choice():
     }
     text = keys.ENTER
 
-    result, cli = feed_app_with_input('list', message, text, **kwargs)
+    result = feed_app_with_input('list', message, text, **kwargs)
     assert result == 'foo'
 
 
@@ -23,7 +23,7 @@ def test_select_second_choice():
     }
     text = keys.DOWN + keys.ENTER
 
-    result, cli = feed_app_with_input('list', message, text, **kwargs)
+    result = feed_app_with_input('list', message, text, **kwargs)
     assert result == 'bar'
 
 
@@ -35,7 +35,7 @@ def test_select_third_choice():
     }
     text = keys.DOWN + keys.DOWN + keys.ENTER
 
-    result, cli = feed_app_with_input('list', message, text, **kwargs)
+    result = feed_app_with_input('list', message, text, **kwargs)
     assert result == 'bazz'
 
 
@@ -47,7 +47,7 @@ def test_cycle_to_first_choice():
     }
     text = keys.DOWN + keys.DOWN + keys.DOWN + keys.ENTER
 
-    result, cli = feed_app_with_input('list', message, text, **kwargs)
+    result = feed_app_with_input('list', message, text, **kwargs)
     assert result == 'foo'
 
 
@@ -59,7 +59,7 @@ def test_cycle_backwards():
     }
     text = keys.UP + keys.ENTER
 
-    result, cli = feed_app_with_input('list', message, text, **kwargs)
+    result = feed_app_with_input('list', message, text, **kwargs)
     assert result == 'bazz'
 
 


### PR DESCRIPTION
This PR contains the minimal amount of changes required for compatibility with prompt_toolkit 3.0.
This means we also have to drop Python 2 support.

I have made sure that the examples still run.
Some remarks:
- style_from_dict is now supposed to be replaced with prompt_toolkit's Style.from_dict
- return_asyncio_coroutine was broken I think. I have removed this part.
- The unit tests for the examples are still failing. This is due to some rendering output that was changed in prompt_toolkit. (Some trailing whitespace is not rendered for instance).
