### PR TITLE
fix usage of prompt in the examples

### DIFF
--- a/examples/checkbox.py
+++ b/examples/checkbox.py
@@ -65,5 +65,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 pprint(answers)

--- a/examples/confirm.py
+++ b/examples/confirm.py
@@ -25,6 +25,6 @@ questions = [
     },
 ]
 
-answers = prompt.prompt(questions, style=custom_style_1)
+answers = prompt(questions, style=custom_style_1)
 pprint(answers)
 

--- a/examples/editor.py
+++ b/examples/editor.py
@@ -22,5 +22,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 pprint(answers)

--- a/examples/expand.py
+++ b/examples/expand.py
@@ -41,5 +41,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 print_json(answers)

--- a/examples/input.py
+++ b/examples/input.py
@@ -44,5 +44,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 pprint(answers)

--- a/examples/list.py
+++ b/examples/list.py
@@ -51,5 +51,5 @@ questions = [
     },
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 pprint(answers)

--- a/examples/password.py
+++ b/examples/password.py
@@ -17,5 +17,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 print_json(answers)

--- a/examples/pizza.py
+++ b/examples/pizza.py
@@ -106,6 +106,6 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_3)
+answers = prompt(questions, style=custom_style_3)
 print('Order receipt:')
 pprint(answers)

--- a/examples/rawlist.py
+++ b/examples/rawlist.py
@@ -32,5 +32,5 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 print_json(answers)

--- a/examples/when.py
+++ b/examples/when.py
@@ -41,6 +41,6 @@ questions = [
     }
 ]
 
-answers = prompt.prompt(questions, style=custom_style_2)
+answers = prompt(questions, style=custom_style_2)
 
 print_json(answers)


### PR DESCRIPTION
For https://github.com/CITGuru/PyInquirer/issues/192

We donot need to use prompt.prompt after importing it from the base PyInquirer module, just using prompt does fine. This PR should fix the above examples