### PR TITLE
Use latest prompt_toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prompt_toolkit>=3.0.0,<3.1.0
+prompt_toolkit>=3.0.0
 Pygments>=2.2.0


### PR DESCRIPTION
This resolves an import error in the collections library when using python 3.10 or higher.

```
ImportError: cannot import name 'Mapping' from 'collections' (/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/collections/__init__.py)
```