### PR TITLE
Update requirements.txt to support collections.abc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prompt_toolkit>=3.0.0,<3.1.0
+prompt_toolkit<2.0.0
 Pygments>=2.2.0


### PR DESCRIPTION
Need for Python > 3.6

After that the from_dict.py is gone. When using version 3.0.43 (newest) I get the error:
```
from PyInquirer import prompt
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/PyInquirer/__init__.py", line 6, in <module>
    from prompt_toolkit.token import Token
ImportError: cannot import name 'Token' from 'prompt_toolkit.token' (/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/prompt_toolkit/token.py)
```