### PR TITLE
fix(checkbox): fix NameError on Token.Error and variable scoping in _get_choice_tokens

### DIFF
--- a/PyInquirer/prompts/checkbox.py
+++ b/PyInquirer/prompts/checkbox.py
@@ -82,8 +82,8 @@ class InquirerControl(FormattedTextControl):
                 else:
                     tokens.append(('', '  ', select_item))
                 # 'o ' - FISHEYE
-                if choice[2]:  # disabled
-                    tokens.append(('', '- %s (%s)' % (choice[0], choice[2])))
+                if line[2]:  # disabled
+                    tokens.append(('', '- %s (%s)' % (line[0], line[2])))
                 else:
                     if selected:
                         tokens.append(('class:selected', '{} '.format(self.selected_sign), select_item))
@@ -93,8 +93,8 @@ class InquirerControl(FormattedTextControl):
                     if pointed_at:
                         tokens.append(('[SetCursorPosition]', ''))
 
-                    if choice[3]:  # description
-                        tokens.append(('', "%s - %s" % (line_name, choice[3])))
+                    if line[3]:  # description
+                        tokens.append(('', "%s - %s" % (line_name, line[3])))
                     else:
                         tokens.append(('', line_name, select_item))
                 tokens.append(('', '\n'))
@@ -160,7 +160,10 @@ def question(message, **kwargs):
                            ' (<up>, <down> to move, <space> to select, <a> '
                            'to toggle, <i> to invert)'))
             if not ic.answered_correctly:
-                tokens.append((Token.Error, ' Error: %s' % ic.error_message))
+                # Use 'class:error' style consistent with prompt_toolkit style tuples.
+                # Previously referenced Token.Error from pygments which was never
+                # imported in this module, causing a NameError on validation failure.
+                tokens.append(('class:error', ' Error: %s' % ic.error_message))
         return tokens
 
     # assemble layout


### PR DESCRIPTION
## Bugs Fixed

### 1. `NameError: name 'Token' is not defined` on validation failure

In `get_prompt_tokens()`, when `ic.answered_correctly` is `False`, the code referenced `Token.Error`:

```python
tokens.append((Token.Error, ' Error: %s' % ic.error_message))
```

`Token` is imported from `pygments.token` only in `PyInquirer/__init__.py`, **never** in `checkbox.py`. This causes an immediate `NameError` crash whenever a checkbox validation fails — the exact moment error feedback is needed most.

**Fix:** Replace with `'class:error'`, consistent with every other style tuple in this file:

```python
tokens.append(('class:error', ' Error: %s' % ic.error_message))
```

---

### 2. Variable scoping bug in `append()` — `choice` vs `line`

Inside `_get_choice_tokens`, the inner helper `append(index, line)` was using the outer `for`-loop variable `choice` instead of its own parameter `line` for indices `[2]` (disabled) and `[3]` (description):

```python
# Before — uses outer loop variable 'choice' inside append(index, line)
if choice[2]:  # disabled
    tokens.append(('', '- %s (%s)' % (choice[0], choice[2])))
...
if choice[3]:  # description
    tokens.append(('', "%s - %s" % (line_name, choice[3])))
```

This works today because `append()` is called immediately in the loop body (so `choice == line` at call time), but it is fragile and misleading — any refactor that defers the call (e.g. storing callbacks, using `map()`) would silently produce wrong output.

**Fix:** Use `line` consistently throughout `append()`:

```python
if line[2]:  # disabled
    tokens.append(('', '- %s (%s)' % (line[0], line[2])))
...
if line[3]:  # description
    tokens.append(('', "%s - %s" % (line_name, line[3])))
```
